### PR TITLE
Corrected an incorrect NFA

### DIFF
--- a/machines/nfafiles/endsin0101.nfa
+++ b/machines/nfafiles/endsin0101.nfa
@@ -25,9 +25,9 @@ NFA
 
 I    : 0|1 -> I
 I    : 0   -> S0
-S0   : 0|1   -> S01
-S01  : 0|1   -> S010
-S010 : 0|1   -> F
+S0   : 1   -> S01
+S01  : 0   -> S010
+S010 : 1   -> F
 
 !!---------------------------------------------------------------------------
 !! You may use the line below as an empty shell to populate for your purposes


### PR DESCRIPTION
This NFA claimed to accept only strings that end with '0101' - it actually accepted any string that had a '0' as its fourth-from-last character.